### PR TITLE
Remove readme

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -3,7 +3,6 @@ name = "dolt_annex"
 version = "0.2.0"
 description = ""
 authors = ["Featherbutt <admin@featherbutt.com>"]
-readme = "../README.md"
 include = [
     { path = "dolt_annex/gallry_dl/gallery_dl_config.json", format = ["sdist", "wheel"] },
     { path = "dolt_annex/gallry_dl/skip.sqlite3", format = ["sdist", "wheel"] },


### PR DESCRIPTION
README.md is no longer mounted by the Dockerfile
via the src directory, so poetry can't find
README.md during container buildtime. I don't
think it's important for poetry to know about, so
removed it from the poetry config.