### PR TITLE
Merge v0.8.1 to main

### DIFF
--- a/src/dolt_annex/__init__.py
+++ b/src/dolt_annex/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import asyncio
-from dolt_annex.commands import gallery_dl_command, init, server_command, import_command, script
+from dolt_annex.commands import gallery_dl_command, init, server_command, script
 from dolt_annex.commands.config import create
 from dolt_annex.commands.sync import push, pull
 from dolt_annex.commands.dataset import DatasetSubcommand
@@ -15,7 +15,6 @@ from .application import Application
 from .gallery_dl_plugin.postprocessors import gallery_dl_post, gallery_dl_prepare, gallery_dl_after
 from .gallery_dl_plugin.test_postprocessors import gallery_dl_post_test
 
-Application.subcommand("import", import_command.Import)
 Application.subcommand("init", init.Init)
 Application.subcommand("push", push.Push)
 Application.subcommand("pull", pull.Pull)

--- a/src/dolt_annex/application.py
+++ b/src/dolt_annex/application.py
@@ -32,7 +32,7 @@ default_config_file_locations = [
 class BaseApplication(CommandGroup):
     """The top level CLI command"""
     PROGNAME = "dolt-annex"
-    VERSION = "0.8.0"
+    VERSION = "0.8.1"
 
     config_file = cli.SwitchAttr(['-c', '--config'], cli.ExistingFile, envname=Env.CONFIG_FILE)
 

--- a/src/dolt_annex/commands/dataset/diff.py
+++ b/src/dolt_annex/commands/dataset/diff.py
@@ -65,7 +65,7 @@ class Diff(cli.Application):
     filters: List[TableFilter] = []
 
     async def main(self, *args: list[str]) -> int:
-        """Entrypoint for pull command"""
+        """Entrypoint for diff command"""
         base_config: Config = self.parent.config
 
         dataset_schema = DatasetSchema.must_load(self.dataset)
@@ -77,6 +77,7 @@ class Diff(cli.Application):
             remote_repo_model = RepoModel.must_load(self.to_repo)
             table_schema = dataset_schema.get_table(self.table_name)
             keys_and_submissions = list(dataset.diff_keys(local_repo_model.uuid, remote_repo_model.uuid, table_schema, self.filters, self.limit))
-            for diff_type, key, submission in keys_and_submissions:
-                    print(",".join([diff_type, str(key), str(submission)]))
+            for diff_type, key, to_submission, from_submission in keys_and_submissions:
+                    # TODO: Display removed rows
+                    print(",".join([diff_type, str(key), str(to_submission)]))
         return 0

--- a/src/dolt_annex/dolt_connection.py
+++ b/src/dolt_annex/dolt_connection.py
@@ -108,18 +108,24 @@ class DoltSqlServer:
         finally:
             connection.close()
 
-    def executemany(self, sql: str, values: List[List[Any]]):
+    def executemany(self, sql: str, values: List[List[Any]], commit = True):
+        if not values:
+            return
         cursor = self.connection.cursor()
         cursor.executemany(sql, values)
-        cursor.execute("COMMIT;")
-        self.connection.commit()
+
+        if commit:
+            cursor.execute("COMMIT;")
+            self.connection.commit()
     
-    def execute(self, sql: str, values):
+    def execute(self, sql: str, values, commit = True):
         cursor = self.connection.cursor()
         cursor.execute(sql, values)
         cursor.fetchall()
-        cursor.execute("COMMIT;")
-        self.connection.commit()
+
+        if commit:
+            cursor.execute("COMMIT;")
+            self.connection.commit()
     
     def query(self, sql: str, values = ()):
         cursor = self.connection.cursor()
@@ -128,6 +134,11 @@ class DoltSqlServer:
         while res:
             yield from res
             res = cursor.fetchmany()
+        cursor.execute("COMMIT;")
+        self.connection.commit()
+
+    def commit_transaction(self):
+        cursor = self.connection.cursor()
         cursor.execute("COMMIT;")
         self.connection.commit()
 

--- a/src/dolt_annex/dolt_connection.py
+++ b/src/dolt_annex/dolt_connection.py
@@ -219,7 +219,7 @@ class DoltSqlServer:
     def merge(self, branch: str):
         """Merge the given branch into the current branch."""
         with self.set_branch(branch):
-            self.commit(amend=True)
+            self.commit(amend=False)
         cursor = self.connection.cursor()
         try:
             cursor.execute("call DOLT_MERGE(%s);", (branch,))

--- a/src/dolt_annex/file_keys/base.py
+++ b/src/dolt_annex/file_keys/base.py
@@ -69,8 +69,15 @@ class FileKey:
                 return subclass.try_parse(key)
         return None
     
+    @overload
     @classmethod
     def must_parse(cls, key: bytes | str) -> Self:
+        ...
+
+    @classmethod
+    def must_parse(cls, key: Optional[bytes | str]) -> Optional[Self]:
+        if key is None:
+            return None
         if isinstance(key, str):
             key = bytes(key, encoding='utf-8')
         file_key = cls.try_parse(key)

--- a/src/dolt_annex/filestore/sftp.py
+++ b/src/dolt_annex/filestore/sftp.py
@@ -43,8 +43,8 @@ class SftpFileStore(FileStore):
         remote_file_path = self.get_key_path(file_key).as_posix()
         await self.sftp.makedirs(Path(remote_file_path).parent.as_posix(), exist_ok=True)
         async with (
-            self.sftp.open(remote_file_path, 'wb') as out_fd,
             data_source as in_fd,
+            self.sftp.open(remote_file_path, 'wb') as out_fd,
         ):
             await copy(src=in_fd, dst=out_fd)
         return Result.done()

--- a/src/dolt_annex/filestore/sqlite.py
+++ b/src/dolt_annex/filestore/sqlite.py
@@ -38,6 +38,7 @@ from dolt_annex.file_keys import FileKey
 from .base import FileInfo, FileStore, FileStoreModel
 
 SQLAR_SCHEMA = """
+PRAGMA journal_mode=WAL;
 CREATE TABLE sqlar(
   name TEXT PRIMARY KEY,  -- name of the file
   mode INT,               -- access permissions

--- a/src/dolt_annex/gallery_dl_plugin/postprocessors.py
+++ b/src/dolt_annex/gallery_dl_plugin/postprocessors.py
@@ -49,7 +49,7 @@ def gallery_dl_post(metadata: dict):
     context.run(insert_metadata(metadata, source, repo_dataset, context.repo))
     context.post_metadata_files_processed += 1
 
-def insert_metadata(metadata: Dict[str, Any], source: GalleryDLSource, repo_dataset: RepoDataset, repo: Repo):
+def serialize_metadata(metadata: Dict[str, Any], source: GalleryDLSource):
     public_metadata = { k: v for k, v in metadata.items() if not source.exclude_field(k) }
 
     metadata_bytes = json.dumps(    
@@ -58,10 +58,11 @@ def insert_metadata(metadata: Dict[str, Any], source: GalleryDLSource, repo_data
         sort_keys=True,
         indent=4,
         default=json_default).encode('utf-8') + b'\n'
-    size = len(metadata_bytes)
-    sha256 = hashlib.sha256(metadata_bytes).hexdigest()
+    return Sha256E.from_bytes(metadata_bytes, "json"), metadata_bytes
 
-    file_key = Sha256E.make(size, sha256, "json")
+
+async def insert_metadata(metadata: Dict[str, Any], source: GalleryDLSource, repo_dataset: RepoDataset, repo: Repo):
+    file_key, metadata_bytes = serialize_metadata(metadata, source)
     metadata["_metadata_file_key"] = file_key
 
     table_row = TableRow({"source": source.source_name, "id": metadata["_id"], "file_key": file_key})
@@ -70,7 +71,8 @@ def insert_metadata(metadata: Dict[str, Any], source: GalleryDLSource, repo_data
     # return matadata file key on insertion
     cas = ContentAddressableStorage(repo.filestore, repo.key_format, repo.alternate_key_formats)
 
-    return import_bytes(cas, table, table_row, metadata_bytes, "json", Sha256E)
+    await import_bytes(cas, table, table_row, metadata_bytes, "json", Sha256E)
+    return file_key
 
 def gallery_dl_prepare(metadata: dict[str, Any]):
     """The entrypoint for 'prepare' postprocessor hooks (run before downloading the file)"""
@@ -131,24 +133,24 @@ def check_skip(source: GalleryDLSource, metadata: dict[str, Any]):
                 TableFilter("id", metadata["_id"])
             ]):
                 metadata_file_key = FileKey.must_parse(row["file_key"])
-                async with repo.filestore.get_file_object(metadata_file_key) as metadata_file:
-                    existing_metadata = json.load(metadata_file)
-                    if source.assume_same_file(metadata, existing_metadata, page_number):
-                        submission_file_key = submissions_table.get_row(filters=[
-                            TableFilter("source", source.source_name),
-                            TableFilter("id", metadata["_id"]),
-                            TableFilter("metadata_file_key", metadata_file_key),
-                            TableFilter("part", page_number),
-                        ])
-                        await submissions_table.insert(TableRow({
-                            "source": source.source_name,
-                            "id": metadata["_id"],
-                            "metadata_file_key": metadata["_metadata_file_key"],
-                            "part": page_number,
-                            "submission_file_key": submission_file_key,
-                        }))
-                        metadata["_skip"] = 1
-                        return
+                metadata_bytes = await repo.filestore.get_file_bytes(metadata_file_key)
+                existing_metadata = json.loads(metadata_bytes)
+                if source.assume_same_file(metadata, existing_metadata, page_number):
+                    submission_file_key = submissions_table.get_row(filters=[
+                        TableFilter("source", source.source_name),
+                        TableFilter("id", metadata["_id"]),
+                        TableFilter("metadata_file_key", metadata_file_key),
+                        TableFilter("part", page_number),
+                    ])
+                    await submissions_table.insert(TableRow({
+                        "source": source.source_name,
+                        "id": metadata["_id"],
+                        "metadata_file_key": metadata["_metadata_file_key"],
+                        "part": page_number,
+                        "submission_file_key": submission_file_key,
+                    }))
+                    metadata["_skip"] = 1
+                    return
 
     context.run(get_files_coro())
     return

--- a/src/dolt_annex/gallery_dl_plugin/sources/e621.py
+++ b/src/dolt_annex/gallery_dl_plugin/sources/e621.py
@@ -44,9 +44,15 @@ class E621(GalleryDLSource, source_name = "e621.net"):
         mutate_remove_fields(metadata, self.fields_to_remove())
         metadata["_id"] = self.id(metadata)
         old_tags = metadata["tags"]
-        if isinstance(old_tags, list):
+        if isinstance(old_tags, dict):
             tag_types = ["artist", "character", "contributor", "copyright", "general", "invalid", "lore", "meta", "species"]
-            tags = { tag_type: metadata.pop(f"tags_{tag_type}", []) for tag_type in tag_types }
-            metadata["tags"] = tags
+            all_tags = []
+            for tag_type in tag_types:
+                metadata[f"tags_{tag_type}"] = old_tags[tag_type]
+                all_tags.extend(old_tags[tag_type])
+            
+            #tags = { tag_type: metadata.pop(f"tags_{tag_type}", []) for tag_type in tag_types }
+            metadata["tags"] = all_tags
+        metadata["tags"].sort()
             
     format_file_metadata = format_post_metadata

--- a/src/dolt_annex/gallery_dl_plugin/sources/furaffinity.py
+++ b/src/dolt_annex/gallery_dl_plugin/sources/furaffinity.py
@@ -32,7 +32,7 @@ class Furaffinity(GalleryDLSource, source_name = "furaffinity.net"):
         mutate_remove_fields(metadata, self.fields_to_remove())
         metadata["_id"] = self.id(metadata)
         tags: list[str] = metadata["tags"]
-        if "Keywords" in tags:
-            tags.remove("Keywords")
-        
-            
+        if "flat" in tags:
+            tags.remove("flat")
+    
+    format_file_metadata = format_post_metadata

--- a/src/dolt_annex/gallery_dl_plugin/sources/furaffinity.py
+++ b/src/dolt_annex/gallery_dl_plugin/sources/furaffinity.py
@@ -32,7 +32,7 @@ class Furaffinity(GalleryDLSource, source_name = "furaffinity.net"):
         mutate_remove_fields(metadata, self.fields_to_remove())
         metadata["_id"] = self.id(metadata)
         tags: list[str] = metadata["tags"]
-        if "flat" in tags:
-            tags.remove("flat")
+        if "Keywords" in tags:
+            tags.remove("Keywords")
     
     format_file_metadata = format_post_metadata

--- a/src/dolt_annex/gallery_dl_plugin/sources/inkbunny.py
+++ b/src/dolt_annex/gallery_dl_plugin/sources/inkbunny.py
@@ -6,7 +6,7 @@ from typing_extensions import Any, override
 
 from .base import GalleryDLSource, UnionPathSelector, mutate_remove_fields
 
-CDN_URL = re.compile("https://(\w+)\\.ib\\.metapix\\.net/(\\S*)")
+CDN_URL = re.compile("https://(\\w+)\\.ib\\.metapix\\.net/(\\S*)")
 
 class Inkbunny(GalleryDLSource, source_name = "inkbunny.net"):
     """Support for inkbunny.net"""

--- a/src/dolt_annex/gallery_dl_plugin/sources/inkbunny.py
+++ b/src/dolt_annex/gallery_dl_plugin/sources/inkbunny.py
@@ -6,7 +6,7 @@ from typing_extensions import Any, override
 
 from .base import GalleryDLSource, UnionPathSelector, mutate_remove_fields
 
-CDN_URL = re.compile("https://(..)\\.ib\\.metapix\\.net/(\\S*)")
+CDN_URL = re.compile("https://(\w+)\\.ib\\.metapix\\.net/(\\S*)")
 
 class Inkbunny(GalleryDLSource, source_name = "inkbunny.net"):
     """Support for inkbunny.net"""

--- a/src/dolt_annex/replicated_db/dolt.py
+++ b/src/dolt_annex/replicated_db/dolt.py
@@ -188,7 +188,13 @@ class FileTable(interface.TableReplica):
     repo_dataset: RepoDataset
     urls: Dict[str, List[str]]
     sources: Dict[FileKey, List[str]]
+    # TODO: Instead of a list of pending inserts and removes, maintain a mapping of
+    # key-value pairs. This allows us to correctly evaluate get_rows for non-flushed tables,
+    # and ensures correct behavior when inserts and removes use the same key. However,
+    # it requires knowledge of which columns are keys and which are values.
+    # We'll need that knowledge when we want to diff secondary indexes anyway.
     added_rows: List[TableRow]
+    removed_rows: List[TableRow]
     batch_size: int
     count: int
     time: float
@@ -203,6 +209,7 @@ class FileTable(interface.TableReplica):
         self.schema = schema
         self.flush_hooks = []
         self.added_rows = []
+        self.removed_rows = []
         self.batch_size = 1000
         self.count = 0
         self.time = time.time()
@@ -228,7 +235,10 @@ class FileTable(interface.TableReplica):
 
     async def insert(self, table_row: TableRow):
         self.added_rows.append(table_row)
+        await self.increment_count()
 
+    async def remove(self, table_row: TableRow):
+        self.removed_rows.append(table_row)
         await self.increment_count()
 
     def add_flush_hook[**P](self, hook: Callable[P, Awaitable[None]], *args: P.args, **kwargs: P.kwargs) -> None:
@@ -237,19 +247,14 @@ class FileTable(interface.TableReplica):
 
     async def flush(self):
         """Flush the cache to the Dolt database and execute callbacks (typically for importing files into filestores)."""
-        # Flushing the cache must be done in the following order:
-        # 1. Update the git-annex branch to contain the new ownership records and registered urls.
-        # 2. Update the Dolt database to match the git-annex branch.
-        # 3. Move the annex files to the annex directory. This step is a no-op when running the downloader,
-        #    because downloaded files were already written into the annex.
-        # This way, if the import process is interrupted, all incomplete files will still exist in the source directory.
-        # Likewise, if a download process is interrupted, the database will still indicate which files have been downloaded.
-
+        
         branch = f"{self.uuid}-{self.dataset.name}"
-        rows = [[row[key] for key in self.schema.all_columns()] for row in self.added_rows]
+        added_rows = [[row[key] for key in self.schema.all_columns()] for row in self.added_rows]
+        removed_rows = [[row[key] for key in self.schema.key_columns] for row in self.removed_rows]
         with self.dolt.maybe_create_branch(branch, self.branch_start_point):
             # pass in dict to insert, correctly make query here
-            self.dolt.executemany(self.insert_sql(), rows)
+            self.dolt.executemany(self.insert_sql(), added_rows)
+            self.dolt.executemany(self.remove_sql(), removed_rows)
 
         for hook in self.flush_hooks:
             await hook()
@@ -288,3 +293,9 @@ class FileTable(interface.TableReplica):
         cols = ", ".join(self.schema.all_columns())
         placeholders = ", ".join(["%s"] * (len(self.schema.all_columns())))
         return f"REPLACE INTO {self.schema.name} ({cols}) VALUES ({placeholders})"
+    
+    def remove_sql(self) -> str:
+        """
+        Returns the SQL statement to insert a row into the table.
+        """
+        return f"DELETE FROM {self.schema.name} WHERE " + " AND ".join([f"{f} = %s" for f in self.schema.key_columns])

--- a/src/dolt_annex/replicated_db/dolt.py
+++ b/src/dolt_annex/replicated_db/dolt.py
@@ -10,7 +10,7 @@ import random
 import time
 from typing import Generator, Self
 from uuid import UUID
-from typing_extensions import Awaitable, Optional, Callable, Dict, List, Tuple, Iterable
+from typing_extensions import Awaitable, Optional, Callable, Dict, List, Tuple, Iterable, Any
 
 from dolt_annex.replicated_db.interface import TableFilter
 from dolt_annex.datatypes import FileKey, TableRow
@@ -88,7 +88,10 @@ def diff_query(file_key_table: FileTableSchema, filters: List[TableFilter]) -> s
     """
     return f"""
         SELECT
-            `diff_type`, `{"to_" + file_key_table.file_column}`, {",".join("to_" + col for col in file_key_table.all_columns())}
+            `diff_type`,
+            `{"to_" + file_key_table.file_column}`,
+            {",".join("to_" + col for col in file_key_table.all_columns())},
+            {",".join("from_" + col for col in file_key_table.all_columns())}
         FROM dolt_commit_diff_{file_key_table.name}
         WHERE from_commit = HASHOF(%s) AND to_commit = HASHOF(%s)
         {''.join(f" AND to_{f.column_name} = %s" for f in filters)}
@@ -118,7 +121,7 @@ class Dataset(interface.ReplicatedDataset):
         self.dolt.maybe_create_branch(f"{repo_uuid}-{dataset_schema.name}", dataset_schema.empty_table_ref)
 
         
-    def diff_keys(self, in_ref: UUID, not_in_ref: UUID, file_key_table: FileTableSchema, filters: List[TableFilter], limit: Optional[int] = None) -> Iterable[Tuple[str, FileKey, TableRow]]:
+    def diff_keys(self, in_ref: UUID, not_in_ref: UUID, file_key_table: FileTableSchema, filters: List[TableFilter], limit: Optional[int] = None) -> Iterable[Tuple[str, FileKey, TableRow, TableRow]]:
         refs = [in_ref, not_in_ref]
         refs.sort()
         union_branch_name = f"union-{refs[0]}-{refs[1]}-{self.name}"
@@ -145,8 +148,11 @@ class Dataset(interface.ReplicatedDataset):
                 query_results = dolt.query(query, (not_in_ref_branch, union_branch_name))
             # TODO: Wrap this in a helper function
             for (diff_type, annex_key, *key_parts) in query_results:
-                table_row = {key: value for key, value in zip(file_key_table.all_columns(), key_parts)}
-                yield (diff_type, FileKey.must_parse(bytes(annex_key, encoding='utf-8')), TableRow(table_row))
+                to_key_parts = key_parts[:len(key_parts)//2]
+                from_key_parts = key_parts[len(key_parts)//2:]
+                to_table_row = {key: value for key, value in zip(file_key_table.all_columns(), to_key_parts)}
+                from_table_row = {key: value for key, value in zip(file_key_table.all_columns(), from_key_parts)}
+                yield (diff_type, FileKey.must_parse(annex_key), TableRow(to_table_row), TableRow(from_table_row))
 
     @asynccontextmanager
     async def with_repo(self, repo: Repo.Id):
@@ -252,10 +258,13 @@ class FileTable(interface.TableReplica):
         added_rows = [[row[key] for key in self.schema.all_columns()] for row in self.added_rows]
         removed_rows = [[row[key] for key in self.schema.key_columns] for row in self.removed_rows]
         with self.dolt.maybe_create_branch(branch, self.branch_start_point):
-            if added_rows:
-                self.dolt.executemany(self.insert_sql(), added_rows)
+            # Execute the remove statement first in case we're replacing a row with the same primary key: insert should win.
+            # But don't commit the transaction until both have executed, otherwise we could lose data if the insert doesn't finish.
             if removed_rows:
-                self.dolt.execute(self.remove_sql(removed_rows), removed_rows)
+                self.dolt.execute(self.remove_sql(removed_rows), removed_rows, commit=False)
+            if added_rows:
+                self.dolt.executemany(self.insert_sql(), added_rows, commit=False)
+            self.dolt.commit_transaction()
 
         for hook in self.flush_hooks:
             await hook()

--- a/src/dolt_annex/replicated_db/dolt.py
+++ b/src/dolt_annex/replicated_db/dolt.py
@@ -252,15 +252,17 @@ class FileTable(interface.TableReplica):
         added_rows = [[row[key] for key in self.schema.all_columns()] for row in self.added_rows]
         removed_rows = [[row[key] for key in self.schema.key_columns] for row in self.removed_rows]
         with self.dolt.maybe_create_branch(branch, self.branch_start_point):
-            # pass in dict to insert, correctly make query here
-            self.dolt.executemany(self.insert_sql(), added_rows)
-            self.dolt.executemany(self.remove_sql(), removed_rows)
+            if added_rows:
+                self.dolt.executemany(self.insert_sql(), added_rows)
+            if removed_rows:
+                self.dolt.execute(self.remove_sql(removed_rows), removed_rows)
 
         for hook in self.flush_hooks:
             await hook()
 
         num_keys = len(self.added_rows)
         self.added_rows.clear()
+        self.removed_rows.clear()
 
         new_now = time.time()
         elapsed_time = new_now - self.time
@@ -294,8 +296,9 @@ class FileTable(interface.TableReplica):
         placeholders = ", ".join(["%s"] * (len(self.schema.all_columns())))
         return f"REPLACE INTO {self.schema.name} ({cols}) VALUES ({placeholders})"
     
-    def remove_sql(self) -> str:
+    def remove_sql(self, values: Iterable[Iterable[Any]]) -> str:
         """
-        Returns the SQL statement to insert a row into the table.
+        Returns the SQL statement to delete rows into the table.
         """
-        return f"DELETE FROM {self.schema.name} WHERE " + " AND ".join([f"{f} = %s" for f in self.schema.key_columns])
+        sets = f"({','.join('%s' for _ in values)})"
+        return f"DELETE FROM {self.schema.name} WHERE ({','.join(self.schema.key_columns)}) IN {sets}"

--- a/src/dolt_annex/replicated_db/interface.py
+++ b/src/dolt_annex/replicated_db/interface.py
@@ -14,6 +14,8 @@ One of the current obstacles is that we need branches in order to merge.
 An abstract "versioned database" provides a way to diff and merge different versions of a table without directly using Dolt.
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Iterable, List, Optional, Self, Tuple

--- a/src/dolt_annex/scripts/gallery_dl_update_metadata.py
+++ b/src/dolt_annex/scripts/gallery_dl_update_metadata.py
@@ -13,20 +13,19 @@ import logging
 from typing_extensions import Literal
 from plumbum import cli
 
-from dolt_annex.application import parse_args
 from dolt_annex.datatypes.async_utils import as_acm
+from dolt_annex.datatypes.common import TableRow
 from dolt_annex.datatypes.repo import Repo
 from dolt_annex.datatypes.table import DatasetSchema
 from dolt_annex.file_keys.base import FileKey
-from dolt_annex.gallery_dl_plugin.postprocessors import insert_metadata
+from dolt_annex.gallery_dl_plugin.postprocessors import insert_metadata, serialize_metadata
 from dolt_annex.gallery_dl_plugin.sources import remove_metadata, category_to_source
 from dolt_annex.replicated_db.dolt import DatabaseConnection
+from dolt_annex.replicated_db.interface import TableFilter
 
 logger = logging.getLogger(__name__)
 
-application, tailargs = parse_args()
-
-class StripMetadataCommand(cli.Application):
+class UpdateMetadata(cli.Application):
     batch_size = cli.SwitchAttr(
         "--batch_size",
         int,
@@ -37,7 +36,7 @@ class StripMetadataCommand(cli.Application):
     dataset = cli.SwitchAttr(
         "--dataset",
         str,
-        help="The name of the dataset being imported into",
+        help="The name of the dataset to update",
         default="gallery-dl",
     )
 
@@ -48,9 +47,6 @@ class StripMetadataCommand(cli.Application):
     )
 
     async def main(self, *args) -> Literal[0,1]:
-        # This command is not finished yet.
-        return 1
-    
         dataset_name = self.dataset
 
         dataset_schema = DatasetSchema.must_load(dataset_name)
@@ -62,17 +58,34 @@ class StripMetadataCommand(cli.Application):
             dataset.with_repo(repo.uuid) as dataset_repo,
         ):
             metadata_table = dataset_repo.get_table("metadata")
-            for row in metadata_table.get_rows():
-                metadata_file_key = row["file_key"]
-                assert isinstance(metadata_file_key, str)
-                metadata_bytes = await repo.filestore.get_file_bytes(FileKey.must_parse(metadata_file_key))
+            submissions_table = dataset_repo.get_table("submissions")
+            for old_metadata_row in metadata_table.get_rows():
+                old_metadata_file_key = FileKey.must_parse(old_metadata_row["file_key"])
+                metadata_bytes = await repo.filestore.get_file_bytes(old_metadata_file_key)
                 metadata = json.loads(metadata_bytes)
                 new_metadata = remove_metadata(metadata)
                 category = new_metadata["category"]
                 source = category_to_source[category]
-                if new_metadata != metadata:
+                new_metadata_file_key, _ = serialize_metadata(new_metadata, source)
+                if new_metadata_file_key != old_metadata_file_key:
                     await insert_metadata(new_metadata, source, dataset_repo, repo)
-                    # TODO: Replace instead of insert
+                    for old_submission_row in submissions_table.get_rows(filters=[
+                        TableFilter("source", old_metadata_row["source"]),
+                        TableFilter("id", old_metadata_row["id"]),
+                        TableFilter("metadata_file_key", str(old_metadata_file_key))
+                    ]):
+                        await submissions_table.insert(TableRow({
+                            "source": old_submission_row["source"],
+                            "id": old_submission_row["id"],
+                            "metadata_file_key": new_metadata_file_key,
+                            "part": old_submission_row["part"],
+                            "submission_file_key": old_submission_row["submission_file_key"],
+                        }))
+                        await submissions_table.remove(old_submission_row)
+                    await metadata_table.remove(old_metadata_row)
+
+                    logger.info(f"moving {old_metadata_row} to {new_metadata_file_key}")
+
         return 0
 
-Command = StripMetadataCommand
+Command = UpdateMetadata

--- a/src/dolt_annex/scripts/gallery_dl_update_metadata.py
+++ b/src/dolt_annex/scripts/gallery_dl_update_metadata.py
@@ -10,7 +10,7 @@ submissions table to use the new file key as the submissions table key.
 
 import json
 import logging
-from typing_extensions import Literal
+from typing_extensions import Literal, List
 from plumbum import cli
 
 from dolt_annex.datatypes.async_utils import as_acm
@@ -46,6 +46,22 @@ class UpdateMetadata(cli.Application):
         help="If set, use the specified repo instead of the default repo",
     )
 
+    filters: List[TableFilter] = []
+
+    @cli.switch(
+        "--where",
+        str,
+        list = True,
+        help="A filter condition on the table rows to be read",
+    )
+    def where(self, filter_strings: List[str]):
+        for filter_string in filter_strings:
+            if '=' not in filter_string:
+                raise ValueError(f"Invalid filter string: {filter_string}")
+            column_name, column_value = filter_string.split('=', maxsplit=1)
+            self.filters.append(TableFilter(column_name, column_value))
+
+
     async def main(self, *args) -> Literal[0,1]:
         dataset_name = self.dataset
 
@@ -59,7 +75,7 @@ class UpdateMetadata(cli.Application):
         ):
             metadata_table = dataset_repo.get_table("metadata")
             submissions_table = dataset_repo.get_table("submissions")
-            for old_metadata_row in metadata_table.get_rows():
+            for old_metadata_row in metadata_table.get_rows(filters=self.filters):
                 old_metadata_file_key = FileKey.must_parse(old_metadata_row["file_key"])
                 metadata_bytes = await repo.filestore.get_file_bytes(old_metadata_file_key)
                 metadata = json.loads(metadata_bytes)
@@ -85,6 +101,8 @@ class UpdateMetadata(cli.Application):
                     await metadata_table.remove(old_metadata_row)
 
                     logger.info(f"moving {old_metadata_row} to {new_metadata_file_key}")
+                else:
+                    logger.info(f"no updates for {old_metadata_row}")
 
         return 0
 

--- a/src/dolt_annex/scripts/import.py
+++ b/src/dolt_annex/scripts/import.py
@@ -223,3 +223,5 @@ async def move_files(file_store: FileStore, import_config: ImportConfig, files: 
             pass
     
     files.clear()
+
+Command = Import

--- a/src/dolt_annex/scripts/import_test.py
+++ b/src/dolt_annex/scripts/import_test.py
@@ -31,7 +31,7 @@ async def test_import(temp_dir, setup):
     )
     await run(
         args=[
-            "dolt-annex", "import", "--force",
+            "dolt-annex", "script", "import", "--", "--force",
             "--importer", "gallerydl.GalleryDL test.com",
             "--move",
             "--dataset",  "gallery-dl",

--- a/src/dolt_annex/sync/__init__.py
+++ b/src/dolt_annex/sync/__init__.py
@@ -81,11 +81,23 @@ class SyncOperation:
                 raise ExceptionGroup("exceptions during sync", self.pending_exceptions)
             await self.to_table.flush()
 
-    async def move_submissions_and_keys(self, keys_and_submissions: Iterable[Tuple[str, FileKey, TableRow]]) -> bool:
+    async def move_submissions_and_keys(self, keys_and_submissions: Iterable[Tuple[str, FileKey, TableRow, TableRow]]) -> bool:
         has_more = False
-        for diff_type, key, table_row in keys_and_submissions:
+        for diff_type, key, to_table_row, from_table_row in keys_and_submissions:
             has_more = True
-            await self.work_queue.put((key, table_row))
+            match diff_type:
+                case "added": 
+                    await self.work_queue.put((key, to_table_row))
+                case "removed":
+                    from_table_key = { column: from_table_row[column] for column in self.to_table.schema.key_columns }
+                    await self.to_table.remove(from_table_key)
+                case "modified":
+                    await self.work_queue.put((key, to_table_row))
+                    from_table_key = { column: from_table_row[column] for column in self.to_table.schema.key_columns }
+                    await self.to_table.remove(from_table_key)
+                case _:
+                    raise ValueError(f"Unknown diff type {diff_type}")
+                    
         return has_more
     
     async def move_submission_and_key(self, key: FileKey, table_row: TableRow) -> Result[None]:

--- a/src/dolt_annex/sync/sync_test.py
+++ b/src/dolt_annex/sync/sync_test.py
@@ -65,7 +65,7 @@ async def test_detect_corruption(
 ):
     from_repo = setup.local_repo
     to_repo = setup.remote_repo
-    FILTERS = [] # Allow for any setup delays
+    FILTERS = []
     async with (
         as_acm(DatabaseConnection.open(setup.config)) as conn,
         as_acm(conn.open_dataset(test_dataset_schema)) as dataset,
@@ -97,7 +97,7 @@ async def test_async_move(
 ):
     from_repo = setup.local_repo
     to_repo = setup.remote_repo
-    FILTERS = [] # Allow for any setup delays
+    FILTERS = []
     async with (
         as_acm(DatabaseConnection.open(test_config)) as conn,
         as_acm(conn.open_dataset(test_dataset_schema)) as dataset,
@@ -120,8 +120,7 @@ async def test_async_move(
         )
         # Check that files have been moved
         for file_key in added_file_keys:
-            assert await maybe_await(to_repo.filestore.exists(file_key))
-            assert await to_repo.filestore.get_file_bytes(file_key) == await from_repo.filestore.get_file_bytes(file_key)
+            await to_repo.filestore.verify_file(file_key)
         # Check that db entries have been updated
         to_table = from_repo_dataset.get_table("test_table")
         for row in to_table.get_rows():
@@ -137,3 +136,82 @@ async def test_async_move(
                 name, offset, size = file_location.split(b":")
                 archive_ids.add(name)
             # assert len(archive_ids) > 1
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("local_filestore_model", [pytest.param(MemoryFSModel(), id=pytest.HIDDEN_PARAM)])
+@pytest.mark.parametrize("remote_filestore_model", [pytest.param(MemoryFSModel(), id="")])
+async def test_diff_types(
+    test_config: Config,
+    setup: EnvironmentForTest,
+):
+    from_repo = setup.local_repo
+    to_repo = setup.remote_repo
+    FILTERS = []
+    async with (
+        as_acm(DatabaseConnection.open(test_config)) as conn,
+        as_acm(conn.open_dataset(test_dataset_schema)) as dataset,
+        dataset.with_repo(from_repo.uuid) as from_repo_dataset,
+        dataset.with_repo(to_repo.uuid) as to_repo_dataset,
+    ):
+        
+        file_bytes = random.randbytes(1024**2) # 1 MB
+        file_key_result = await setup.local_file_store.put_file_bytes(file_bytes)
+        file_key = await file_key_result.wait_for_complete()
+        table_row = TableRow({"path": "test_path","file_key": file_key})
+        # Add entries to from_repo database
+        from_table = from_repo_dataset.get_table("test_table")
+        await from_table.insert(table_row)
+
+        await from_table.flush()
+        await move_dataset(
+            dataset,
+            from_repo,
+            to_repo,
+            FILTERS,
+        )
+        # Check that files have been moved
+        await to_repo.filestore.verify_file(file_key)
+        # Check that db entries have been updated
+        to_table = from_repo_dataset.get_table("test_table")
+        rows = list(to_table.get_rows())
+        assert len(rows) == 1
+        assert rows[0]["path"] == "test_path"
+        assert rows[0]["file_key"] == str(file_key)
+        
+        # Modify the table row
+        await from_table.remove(table_row)
+        new_file_bytes = random.randbytes(1024**2) # 1 MB
+        file_key_result = await setup.local_file_store.put_file_bytes(new_file_bytes)
+        new_file_key = await file_key_result.wait_for_complete()
+        new_table_row = TableRow({"path": "test_path", "file_key": new_file_key})
+        await from_table.insert(new_table_row)
+
+        await from_table.flush()
+        await move_dataset(
+            dataset,
+            from_repo,
+            to_repo,
+            FILTERS,
+        )
+
+        # Check that files have been moved
+        await to_repo.filestore.verify_file(new_file_key)
+        # Check that db entries have been updated
+        rows = list(to_table.get_rows())
+        assert len(rows) == 1
+        assert rows[0]["path"] == "test_path"
+        assert rows[0]["file_key"] == str(new_file_key)
+
+        # Delete the table row
+        await from_table.remove(new_table_row)
+
+        await from_table.flush()
+        await move_dataset(
+            dataset,
+            from_repo,
+            to_repo,
+            FILTERS,
+        )
+
+        rows = list(to_table.get_rows())
+        assert len(rows) == 0

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dolt_annex"
-version = "0.8.0"
+version = "0.8.1"
 description = ""
 authors = ["Featherbutt <admin@featherbutt.com>"]
 include = [


### PR DESCRIPTION
Lots of small fixes and improvements in this version, including:
- Fixed various issues when obtaining metadata in `dolt-annex gallery-dl`
- Allow for normalizing metadata obtained from different versions of gallery-dl
- When using the SQLite filestore option, use WAL mode so that multiple processes can connect concurrently
- Correctly handle `dolt-annex push` and `dolt-annex pull` when one repo has changes to existing table rows

The `dolt-annex import` command has been converted into a script in the scripts directory, since there's currently no reason for a new user to use it.

The CI failure is because gallery-dl is currently broken for downloads from furaffinity.net. Once that's fixed, I'll bump the version of the gallery-dl in the dependencies and cut a patch release.